### PR TITLE
Allow dynamic filters to override the static ones

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -481,7 +481,7 @@ impl EnvFilter {
         // is it possible for a dynamic filter directive to enable this event?
         // if not, we can avoid the thread loca'l access + iterating over the
         // spans in the current scope.
-        if self.has_dynamics && self.dynamics.max_level >= *level {
+        if self.has_dynamics {
             if metadata.is_span() {
                 // If the metadata is a span, see if we care about its callsite.
                 let enabled_by_cs = self
@@ -501,6 +501,10 @@ impl EnvFilter {
                     if filter >= level {
                         return true;
                     }
+                }
+                if !scope.is_empty() {
+                    // at least one dynamic filter disabled this
+                    return false;
                 }
                 false
             };
@@ -619,14 +623,19 @@ impl EnvFilter {
     }
 
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
-        if self.has_dynamics && metadata.is_span() {
-            // If this metadata describes a span, first, check if there is a
-            // dynamic filter that should be constructed for it. If so, it
-            // should always be enabled, since it influences filtering.
-            if let Some(matcher) = self.dynamics.matcher(metadata) {
-                let mut by_cs = try_lock!(self.by_cs.write(), else return self.base_interest());
-                by_cs.insert(metadata.callsite(), matcher);
-                return Interest::always();
+        if self.has_dynamics {
+            if metadata.is_span() {
+                // If this metadata describes a span, first, check if there is a
+                // dynamic filter that should be constructed for it. If so, it
+                // should always be enabled, since it influences filtering.
+                if let Some(matcher) = self.dynamics.matcher(metadata) {
+                    let mut by_cs = try_lock!(self.by_cs.write(), else return self.base_interest());
+                    by_cs.insert(metadata.callsite(), matcher);
+                    return Interest::always();
+                }
+            } else if *metadata.level() <= self.dynamics.max_level {
+                // Any dynamic could turn this metadata off
+                return Interest::sometimes();
             }
         }
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -633,7 +633,11 @@ impl EnvFilter {
                     by_cs.insert(metadata.callsite(), matcher);
                     return Interest::always();
                 }
-            } else if *metadata.level() <= self.dynamics.max_level {
+            } else if self
+                .dynamics
+                .directives()
+                .any(|directive| directive.level < *metadata.level())
+            {
                 // Any dynamic could turn this metadata off
                 return Interest::sometimes();
             }

--- a/tracing-subscriber/tests/env_filter/main.rs
+++ b/tracing-subscriber/tests/env_filter/main.rs
@@ -9,6 +9,7 @@ mod per_layer;
 use tracing::{self, subscriber::with_default, Level};
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
+    layer::Layered,
     prelude::*,
 };
 
@@ -237,6 +238,32 @@ fn method_name_resolution() {
 
     let filter = EnvFilter::new("hello_world=info");
     filter.max_level_hint();
+}
+
+#[test]
+fn more_specific_dynamic_directives_override_static_directives() {
+    let filter: EnvFilter = "info,my_target[my_span]=warn".parse().unwrap();
+    let (subscriber, handle) = subscriber::mock()
+        .enter(span::mock().at_level(Level::INFO))
+        .event(
+            event::mock()
+                .at_level(Level::WARN)
+                .in_scope(vec![span::named("my_span")]),
+        )
+        .exit(span::mock().at_level(Level::INFO))
+        .done()
+        .run_with_handle();
+
+    let subscriber: Layered<_, _> = subscriber.with(filter);
+
+    with_default(subscriber, || {
+        // tracing::info!("should be logged");
+        let _info = tracing::info_span!(target: "my_target", "my_span").entered();
+        tracing::info!("should be ignored");
+        tracing::warn!("should be logged");
+    });
+
+    handle.assert_finished();
 }
 
 // contains the same tests as the first half of this file

--- a/tracing-subscriber/tests/env_filter/main.rs
+++ b/tracing-subscriber/tests/env_filter/main.rs
@@ -244,6 +244,7 @@ fn method_name_resolution() {
 fn more_specific_dynamic_directives_override_static_directives() {
     let filter: EnvFilter = "info,my_target[my_span]=warn".parse().unwrap();
     let (subscriber, handle) = subscriber::mock()
+        .event(event::mock().at_level(Level::INFO).with_target("env_filter"))
         .enter(span::mock().at_level(Level::INFO))
         .event(
             event::mock()
@@ -257,10 +258,10 @@ fn more_specific_dynamic_directives_override_static_directives() {
     let subscriber: Layered<_, _> = subscriber.with(filter);
 
     with_default(subscriber, || {
-        // tracing::info!("should be logged");
+        tracing::info!("regular event should be logged");
         let _info = tracing::info_span!(target: "my_target", "my_span").entered();
-        tracing::info!("should be ignored");
-        tracing::warn!("should be logged");
+        tracing::info!("span INFO event should be ignored");
+        tracing::warn!("span WARN event should be logged");
     });
 
     handle.assert_finished();

--- a/tracing-subscriber/tests/env_filter/per_layer.rs
+++ b/tracing-subscriber/tests/env_filter/per_layer.rs
@@ -308,6 +308,7 @@ fn multiple_dynamic_filters() {
 fn more_specific_dynamic_directives_override_static_directives() {
     let filter: EnvFilter = "info,my_target[my_span]=warn".parse().unwrap();
     let (layer, handle) = layer::mock()
+        .event(event::mock().at_level(Level::INFO).with_target("my_target"))
         .enter(span::mock().at_level(Level::INFO))
         .event(
             event::mock()
@@ -323,9 +324,10 @@ fn more_specific_dynamic_directives_override_static_directives() {
         .set_default();
 
     {
+        tracing::info!(target: "my_target", "regular event should be logged");
         let _info = tracing::info_span!(target: "my_target", "my_span").entered();
-        tracing::info!(target: "my_target", "should be ignored");
-        tracing::warn!(target: "my_target", "should be logged");
+        tracing::info!(target: "my_target", "span INFO event should be ignored");
+        tracing::warn!(target: "my_target", "span WARN event should be logged");
     }
 
     handle.assert_finished();

--- a/tracing-subscriber/tests/env_filter/per_layer.rs
+++ b/tracing-subscriber/tests/env_filter/per_layer.rs
@@ -303,3 +303,30 @@ fn multiple_dynamic_filters() {
     handle1.assert_finished();
     handle2.assert_finished();
 }
+
+#[test]
+fn more_specific_dynamic_directives_override_static_directives() {
+    let filter: EnvFilter = "info,my_target[my_span]=warn".parse().unwrap();
+    let (layer, handle) = layer::mock()
+        .enter(span::mock().at_level(Level::INFO))
+        .event(
+            event::mock()
+                .at_level(Level::WARN)
+                .in_scope(vec![span::named("my_span")]),
+        )
+        .exit(span::mock().at_level(Level::INFO))
+        .done()
+        .run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(layer.with_filter(filter))
+        .set_default();
+
+    {
+        let _info = tracing::info_span!(target: "my_target", "my_span").entered();
+        tracing::info!(target: "my_target", "should be ignored");
+        tracing::warn!(target: "my_target", "should be logged");
+    }
+
+    handle.assert_finished();
+}


### PR DESCRIPTION
Based on https://github.com/tokio-rs/tracing/pull/2095 Issue https://github.com/tokio-rs/tracing/issues/1388

Allow dynamic filters to override statis cones, thus enabling the possibility to have env filters like
warn,pageserver=info,[{tenant=98d670ab7bee6f0051494306a1ab888f}]=error,[{tenant=19cbf2bf51f42a5a5a90aa8954fb3e42}]=debug
